### PR TITLE
Expand ViewComponent detection logic

### DIFF
--- a/lib/theo-rails/theo.rb
+++ b/lib/theo-rails/theo.rb
@@ -47,17 +47,9 @@ module Theo
           locals = attributes.empty? ? '' : attributes.map { |k, v| "'#{k}': #{v}" }.join(', ')
 
           component = resolve_view_component(partial)
+          is_partial = component.nil?
 
-          if component.present?
-            if content
-              output = "<%= render #{component}.new(#{locals}) do#{yields} %>#{process(content)}<% end %>"
-            elsif collection
-              locals = ", #{locals}" unless locals.empty?
-              output = "<%= render #{component}.with_collection(#{collection}#{locals}) %>"
-            else
-              output = "<%= render #{component}.new(#{locals}) %>"
-            end
-          else
+          if is_partial
             partial = partial.delete_prefix('_').underscore
 
             partial = "#{path}/#{partial}" if path
@@ -71,6 +63,15 @@ module Theo
             else
               locals = ", locals: {#{locals}}" unless locals.empty?
               output = "<%= render partial: '#{partial}'#{collection}#{locals} %>"
+            end
+          else
+            if content
+              output = "<%= render #{component}.new(#{locals}) do#{yields} %>#{process(content)}<% end %>"
+            elsif collection
+              locals = ", #{locals}" unless locals.empty?
+              output = "<%= render #{component}.with_collection(#{collection}#{locals}) %>"
+            else
+              output = "<%= render #{component}.new(#{locals}) %>"
             end
           end
 
@@ -109,7 +110,7 @@ module Theo
 
         # safe_constantize ensures PascalCase
         klass = component.safe_constantize || "#{component}Component".safe_constantize
-        klass.name if klass&.< ViewComponent::Base
+        klass.name if klass && klass < ViewComponent::Base
       end
 
       def translate_location(spot, backtrace_location, source)

--- a/lib/theo-rails/theo.rb
+++ b/lib/theo-rails/theo.rb
@@ -107,9 +107,9 @@ module Theo
       def resolve_view_component(component)
         return unless view_component_loaded?
 
-        # safe_constantize ensures CamelCase
+        # safe_constantize ensures PascalCase
         klass = component.safe_constantize || "#{component}Component".safe_constantize
-        klass.to_s if klass&.< ViewComponent::Base
+        klass.name if klass&.< ViewComponent::Base
       end
 
       def translate_location(spot, backtrace_location, source)

--- a/spec/theo-rails/theo_spec.rb
+++ b/spec/theo-rails/theo_spec.rb
@@ -3,6 +3,15 @@ require 'spec_helper'
 class WidgetComponent < ViewComponent::Base
 end
 
+class Button < ViewComponent::Base
+end
+
+class Avatar < ViewComponent::Base
+end
+
+class AvatarComponent < ViewComponent::Base
+end
+
 RSpec.shared_examples 'theo to erb' do |name, input, output|
   let(:theo) { Theo::Rails::Theo.new }
 
@@ -145,6 +154,22 @@ RSpec.describe Theo::Rails::Theo do
       include_examples 'theo to erb', 'evaluates partial collection with attributes',
                        %(<Widget collection="widgets" attr1="value1" attr2="value2" />),
                        %(<%= render WidgetComponent.with_collection(widgets, 'attr1': 'value1', 'attr2': 'value2') %>)
+    end
+
+    context 'component without "Component" suffix' do
+      include_examples 'theo to erb', 'evaluates simple component',
+                       %(<Button />),
+                       %(<%= render Button.new() %>)
+    end
+
+    context 'competing component names' do
+      include_examples 'theo to erb', 'evaluates direct match',
+                       %(<Avatar />),
+                       %(<%= render Avatar.new() %>)
+
+      include_examples 'theo to erb', 'evaluates direct match with "Component" suffix',
+                       %(<AvatarComponent />),
+                       %(<%= render AvatarComponent.new() %>)
     end
   end
 


### PR DESCRIPTION
Although, [ViewComponent conventions](https://viewcomponent.org/guide/getting-started.html#conventions) suggest that component names end in `Component`, the suffix may be dropped once components are namespaced, e.g. `Ui::Button`. Even Primer ViewComponents omit the suffix.

This PR expands Theo`s detection logic to support arbitrary component names.

New behavior:
```erb
<%# 
  class Widget < ViewComponent::Base; end
  class WidgetComponent < ViewComponent::Base; end
%>

<Widget />
#=> <%= render Widget.new() %>

<WidgetComponent />
#=> <%= render WidgetComponent.new() %>
```

Preserved behavior:
```erb
<%#
  class ButtonComponent < ViewComponent::Base; end
%>

<Button />
#=> <%= render ButtonComponent.new() %>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced component rendering logic with improved resolution and handling of components and partials.
	- Added support for components with and without "Component" suffix.

- **Tests**
	- Expanded test suite with new component classes (Button, Avatar, AvatarComponent).
	- Added test cases for component name variations and rendering scenarios.

- **Refactor**
	- Streamlined rendering method in Theo class.
	- Improved component resolution process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->